### PR TITLE
Fixing a json test failure

### DIFF
--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "json"
 
 describe GamesController do
   describe "new" do
@@ -142,7 +143,8 @@ describe GamesController do
 
         get :show, :id => game, :format => :json
 
-        response.body.should == {
+        json_data = JSON.parse(response.body)
+        json_data.should == {
           "name" => game.name,
           "ratings" => [
             {"player" => {"name" => player1.name, "email" => player1.email}, "value" => 1003},
@@ -154,7 +156,7 @@ describe GamesController do
             {"winner" => player2.name, "loser" => player3.name, "created_at" => Time.now.utc.to_s},
             {"winner" => player3.name, "loser" => player1.name, "created_at" => Time.now.utc.to_s}
           ]
-        }.to_json
+        }
       end
     end
   end


### PR DESCRIPTION
The game controller tests compare json strings directly which is not guaranteed to work as the object members may be serialized in different orders.  Changed to compare the parsed json object.
