### PR TITLE
Add Decimal Support to rating

### DIFF
--- a/app/models/rater.rb
+++ b/app/models/rater.rb
@@ -10,6 +10,10 @@ module Rater
       "Elo (1v1 only)"
     end
 
+    def coerce_value(value)
+      value.to_i
+    end
+
     def validate_game game
       if game.min_number_of_teams != 2 ||
          game.max_number_of_teams != 2 ||
@@ -76,6 +80,10 @@ module Rater
 
     def description
       "Trueskill"
+    end
+
+    def coerce_value(value)
+      BigDecimal(value)
     end
 
     def validate_game game

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -11,6 +11,10 @@ class Rating < ActiveRecord::Base
     end
   end
 
+  def value
+    game.rater.coerce_value(super)
+  end
+
   def as_json(option = {})
     {
       :player => player.as_json,

--- a/app/models/rating_history_event.rb
+++ b/app/models/rating_history_event.rb
@@ -1,3 +1,6 @@
 class RatingHistoryEvent < ActiveRecord::Base
   belongs_to :rating
+  def value
+    rating.game.rater.coerce_value(super)
+  end
 end

--- a/db/migrate/20130201145207_change_value_column_to_decimal.rb
+++ b/db/migrate/20130201145207_change_value_column_to_decimal.rb
@@ -1,0 +1,11 @@
+class ChangeValueColumnToDecimal < ActiveRecord::Migration
+  def up
+    change_column :ratings, :value, :decimal, {:scale => 4, :precision => 10}
+    change_column :rating_history_events, :value, :decimal, {:scale => 4, :precision => 10}
+  end
+
+  def down
+    change_column :ratings, :value, :integer
+    change_column :rating_history_events, :value, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 6) do
+ActiveRecord::Schema.define(:version => 20130201145207) do
 
   create_table "games", :force => true do |t|
     t.string   "name",                           :null => false
@@ -38,10 +38,10 @@ ActiveRecord::Schema.define(:version => 6) do
   end
 
   create_table "rating_history_events", :force => true do |t|
-    t.integer  "rating_id",           :null => false
-    t.integer  "value",               :null => false
-    t.datetime "created_at",          :null => false
-    t.datetime "updated_at",          :null => false
+    t.integer  "rating_id",                                          :null => false
+    t.decimal  "value",               :precision => 10, :scale => 4, :null => false
+    t.datetime "created_at",                                         :null => false
+    t.datetime "updated_at",                                         :null => false
     t.float    "trueskill_mean"
     t.float    "trueskill_deviation"
   end
@@ -49,12 +49,12 @@ ActiveRecord::Schema.define(:version => 6) do
   add_index "rating_history_events", ["rating_id"], :name => "index_rating_history_events_on_rating_id"
 
   create_table "ratings", :force => true do |t|
-    t.integer  "player_id",           :null => false
-    t.integer  "game_id",             :null => false
-    t.integer  "value",               :null => false
-    t.boolean  "pro",                 :null => false
-    t.datetime "created_at",          :null => false
-    t.datetime "updated_at",          :null => false
+    t.integer  "player_id",                                          :null => false
+    t.integer  "game_id",                                            :null => false
+    t.decimal  "value",               :precision => 10, :scale => 4, :null => false
+    t.boolean  "pro",                                                :null => false
+    t.datetime "created_at",                                         :null => false
+    t.datetime "updated_at",                                         :null => false
     t.float    "trueskill_mean"
     t.float    "trueskill_deviation"
   end

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -129,7 +129,7 @@ describe GamesController do
 
     it "returns a json response" do
       Timecop.freeze(Time.now) do
-        game = FactoryGirl.create(:game)
+        game = FactoryGirl.create(:elo_game)
 
         player1 = FactoryGirl.create(:player)
         player2 = FactoryGirl.create(:player)

--- a/spec/models/rater_spec.rb
+++ b/spec/models/rater_spec.rb
@@ -132,7 +132,7 @@ describe Rater do
 
   describe Rater::TrueSkillRater do
     describe "update_ratings" do
-      let(:game) { FactoryGirl.create(:game, max_number_of_teams: nil, max_number_of_players_per_team: nil) }
+      let(:game) { FactoryGirl.create(:game, max_number_of_teams: nil, max_number_of_players_per_team: nil, rating_type: "trueskill") }
       let(:player1) { FactoryGirl.create(:player) }
       let(:player2) { FactoryGirl.create(:player) }
       let(:player3) { FactoryGirl.create(:player) }
@@ -217,7 +217,7 @@ describe Rater do
         rating1 = player1.ratings.find_or_create(game)
         rating2 = player2.ratings.find_or_create(game)
 
-        rating1.value.should == (rating1.trueskill_mean - (3 * rating1.trueskill_deviation)).floor
+        rating1.value.should == BigDecimal((rating1.trueskill_mean - (3 * rating1.trueskill_deviation).to_f), 6)
         rating1.value.should > rating2.value
       end
 

--- a/spec/models/rating_history_event_spec.rb
+++ b/spec/models/rating_history_event_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe RatingHistoryEvent do
+  describe "value" do
+    it "should return an integer value for elo games" do
+      game = FactoryGirl.create(:elo_game)
+      rating = FactoryGirl.create(:rating, :value => 1000.0, :game => game)
+      history_event = FactoryGirl.build(:rating_history_event, :value => 1000.0, :rating => rating)
+      history_event.value.class.should == Fixnum
+      history_event.value.to_s.should == "1000"
+    end
+
+    it "should return a big decimal value for trueskill games" do
+      game = FactoryGirl.create(:trueskill_game)
+      rating = FactoryGirl.create(:rating, :value => 1000.1234, :game => game)
+      history_event = FactoryGirl.build(:rating_history_event, :value => 1000.1234, :rating => rating)
+      history_event.value.class.should == BigDecimal
+      history_event.value.to_s.should == BigDecimal("1000.1234").to_s
+    end
+  end
+end

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -17,6 +17,22 @@ describe Rating do
     end
   end
 
+  describe "value" do
+    it "should return an integer value for elo games" do
+      game = FactoryGirl.create(:elo_game)
+      rating = FactoryGirl.build(:rating, :value => 1000.0, :game => game)
+      rating.value.class.should == Fixnum
+      rating.value.to_s.should == "1000"
+    end
+
+    it "should return a big decimal value for trueskill games" do
+      game = FactoryGirl.create(:trueskill_game)
+      rating = FactoryGirl.build(:rating, :value => 1000.1234, :game => game)
+      rating.value.class.should == BigDecimal
+      rating.value.to_s.should == BigDecimal("1000.1234").to_s
+    end
+  end
+
   describe "as_json" do
     it "returns the json representation of the result" do
       player = FactoryGirl.build(:player, :name => "John")


### PR DESCRIPTION
Keeps logic for elo games the same by coercing the value of rating to an
integer. Both values are actually stored as BigDecimal in the database.

Phillip thought that a coercion step was crazier than doing something like creating a helper to wrap the value in the view code. 

I don't think that would cover all cases though; For instance, the json services would still report elo values as decimals. My thought is that each games result type determines the class of the value and that that's what we want the rest of the code to use. In the case of elo, that's an integer value. In the case of trueskill, that's a decimal value. So, I redefine the value method for the rating and rating history event to coerce to the correct type. After that, the rest of the codebase (services and view) correctly reports elo ratings and correctly reports trueskill ratings.

I wasn't sure whether you wanted a pull request with migrations collapsed; I assumed not.
