### PR TITLE
Fix "Maximum" form fields displaying 2 when editing

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -23,7 +23,9 @@ class GamesController < ApplicationController
     @game = Game.new min_number_of_players_per_team: 1,
                      rating_type: "trueskill",
                      min_number_of_teams: 2,
-                     allow_ties: true
+                     allow_ties: true,
+                     max_number_of_players_per_team: 2,
+                     max_number_of_teams: 2
   end
 
   def show

--- a/app/views/games/_form.html.erb
+++ b/app/views/games/_form.html.erb
@@ -22,7 +22,7 @@
   <div class="control-group" id='max_players_control_group'>
     <%= f.label :max_number_of_players_per_team, 'Maximum number of players per team', class: "control-label" %>
     <div class="controls">
-      <%= f.number_field :max_number_of_players_per_team, value: 2, class: "input-mini" %>
+      <%= f.number_field :max_number_of_players_per_team, class: "input-mini" %>
       <span class="help-inline">Set to blank for no restriction</span>
     </div>
   </div>
@@ -30,7 +30,7 @@
   <div class="control-group" id='max_teams_control_group'>
     <%= f.label :max_number_of_teams, 'Maximum number of teams', class: "control-label" %>
     <div class="controls">
-      <%= f.number_field :max_number_of_teams, value: 2, class: "input-mini" %>
+      <%= f.number_field :max_number_of_teams, class: "input-mini" %>
       <span class="help-inline">Set to blank for no restriction</span>
     </div>
   </div>


### PR DESCRIPTION
The latest change made the "Maximum number of players per team" and "Maximum number of teams" show a value of `2`, even when editing existing games. 

This change sets those properties to `2` in the controller, so editing an existing game shows the correct values.