### PR TITLE
Fix basic auth

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ module Elovation
     # -- all .rb files in that directory are automatically loaded.
 
     if ENV['BASIC_AUTH'] == "true"
-      config.middleware.use("::Rack::Auth::Basic") do |u, p|
+      config.middleware.use(::Rack::Auth::Basic) do |u, p|
         [u, p] == [ENV['BASIC_AUTH_USER'], ENV['BASIC_AUTH_PASSWORD']]
       end
     end


### PR DESCRIPTION
In more recent rails version (I didn't take the time to look it up), this needs to be a fully qualified class name and not a string.