### PR TITLE
bugfix: use safe navigation for player rating display

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -55,7 +55,7 @@
               <li>
                 <%= link_to player_path(player) do %>
                   <%= image_tag(gravatar_url(player, size: 24)) %>
-                  <%= player.name %> - <%= player.ratings.last.value %>
+                  <%= player.name %> - <%= player.ratings.last&.value || "Unranked" %>
                 <% end %>
               </li>
             <% end %>

--- a/app/views/players/_player.html.erb
+++ b/app/views/players/_player.html.erb
@@ -3,7 +3,7 @@
     <%= link_to player_path(player), data: { turbo: false } do %>
       <%= image_tag(gravatar_url(player, size: 80)) %>
       <h3> <%= player.name %> </h3>
-      <p> <%= player.email %> <%= player.ratings.last.value %> </p>
+      <p> <%= player.email %> <%= player.ratings.last&.value || "Unranked" %> </p>
     <% end %>
   </li>
 <% end %>


### PR DESCRIPTION
New players have no ratings associated and will cause a crash if ratings are accessed

<img width="1219" height="921" alt="image" src="https://github.com/user-attachments/assets/80f6d4c3-ee1a-4a1b-8e84-991b0e4e2b20" />

Not a big Ruby guy, this fix was suggested by ChatGPT, tried to ask if there was a way to fix it in the Players class instead but didn't get anywhere.
